### PR TITLE
APRL and WAF Alignment Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The following resources are used by this module:
 - [azurerm_role_assignment.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) (resource)
 - [azurerm_service_plan.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/service_plan) (resource)
 - [random_id.telem](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) (resource)
+- [azurerm_location.region](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/location) (data source)
 - [azurerm_resource_group.parent](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) (data source)
 
 <!-- markdownlint-disable MD013 -->
@@ -255,7 +256,7 @@ Description: Should zone balancing be enabled for this App Service Plan.
 
 Type: `bool`
 
-Default: `false`
+Default: `true`
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -90,23 +90,6 @@ Type: `string`
 
 Default: `null`
 
-### <a name="input_customer_managed_key"></a> [customer\_managed\_key](#input\_customer\_managed\_key)
-
-Description: Customer managed keys that should be associated with the resource.
-
-Type:
-
-```hcl
-object({
-    key_vault_resource_id              = optional(string)
-    key_name                           = optional(string)
-    key_version                        = optional(string, null)
-    user_assigned_identity_resource_id = optional(string, null)
-  })
-```
-
-Default: `{}`
-
 ### <a name="input_diagnostic_settings"></a> [diagnostic\_settings](#input\_diagnostic\_settings)
 
 Description: A map of diagnostic settings to create on the Key Vault. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
@@ -161,33 +144,21 @@ Default: `null`
 
 ### <a name="input_lock"></a> [lock](#input\_lock)
 
-Description: The lock level to apply. Default is `None`. Possible values are `None`, `CanNotDelete`, and `ReadOnly`.
+Description:   Controls the Resource Lock configuration for this resource. The following properties can be specified:
+
+  - `kind` - (Required) The type of lock. Possible values are `\"CanNotDelete\"` and `\"ReadOnly\"`.
+  - `name` - (Optional) The name of the lock. If not specified, a name will be generated based on the `kind` value. Changing this forces the creation of a new resource.
 
 Type:
 
 ```hcl
 object({
+    kind = string
     name = optional(string, null)
-    kind = optional(string, "None")
   })
 ```
 
-Default: `{}`
-
-### <a name="input_managed_identities"></a> [managed\_identities](#input\_managed\_identities)
-
-Description: Managed identities to be created for the resource.
-
-Type:
-
-```hcl
-object({
-    system_assigned            = optional(bool, false)
-    user_assigned_resource_ids = optional(set(string), [])
-  })
-```
-
-Default: `{}`
+Default: `null`
 
 ### <a name="input_maximum_elastic_worker_count"></a> [maximum\_elastic\_worker\_count](#input\_maximum\_elastic\_worker\_count)
 
@@ -236,11 +207,11 @@ Default: `{}`
 
 ### <a name="input_tags"></a> [tags](#input\_tags)
 
-Description: The map of tags to be applied to the resource
+Description: (Optional) Tags of the resource.
 
-Type: `map(any)`
+Type: `map(string)`
 
-Default: `{}`
+Default: `null`
 
 ### <a name="input_worker_count"></a> [worker\_count](#input\_worker\_count)
 

--- a/README.md
+++ b/README.md
@@ -178,16 +178,16 @@ Default: `false`
 
 ### <a name="input_role_assignments"></a> [role\_assignments](#input\_role\_assignments)
 
-Description: A map of role assignments to create on this resource. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
+Description:   A map of role assignments to create on the Key Vault. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
 
-- `role_definition_id_or_name` - The ID or name of the role definition to assign to the principal.
-- `principal_id` - The ID of the principal to assign the role to.
-- `description` - The description of the role assignment.
-- `skip_service_principal_aad_check` - If set to true, skips the Azure Active Directory check for the service principal in the tenant. Defaults to false.
-- `condition` - The condition which will be used to scope the role assignment.
-- `condition_version` - The version of the condition syntax. Valid values are '2.0'.
+  - `role_definition_id_or_name` - The ID or name of the role definition to assign to the principal.
+  - `principal_id` - The ID of the principal to assign the role to.
+  - `description` - The description of the role assignment.
+  - `skip_service_principal_aad_check` - If set to true, skips the Azure Active Directory check for the service principal in the tenant. Defaults to false.
+  - `condition` - The condition which will be used to scope the role assignment.
+  - `condition_version` - The version of the condition syntax. Leave as `null` if you are not using a condition, if you are then valid values are '2.0'.
 
-> Note: only set `skip_service_principal_aad_check` to true if you are assigning a role to a service principal.
+  > Note: only set `skip_service_principal_aad_check` to true if you are assigning a role to a service principal.
 
 Type:
 

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -60,7 +60,7 @@ module "test" {
   enable_telemetry    = var.enable_telemetry # see variables.tf
   name                = "web-serverfarm"
   resource_group_name = azurerm_resource_group.this.name
-  sku_name            = "S1"
+  sku_name            = "P1v3"
   os_type             = "Linux"
 }
 ```

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -54,6 +54,6 @@ module "test" {
   enable_telemetry    = var.enable_telemetry # see variables.tf
   name                = "web-serverfarm"
   resource_group_name = azurerm_resource_group.this.name
-  sku_name            = "S1"
+  sku_name            = "P1v3"
   os_type             = "Linux"
 }

--- a/locals.tf
+++ b/locals.tf
@@ -3,8 +3,3 @@ locals {
   resource_group_location            = try(data.azurerm_resource_group.parent[0].location, null)
   role_definition_resource_substring = "/providers/Microsoft.Authorization/roleDefinitions"
 }
-
-# Private endpoint application security group associations
-# Remove if this resource does not support private endpoints
-locals {
-}

--- a/main.tf
+++ b/main.tf
@@ -23,15 +23,15 @@ resource "azurerm_service_plan" "this" {
 }
 
 # required AVM resources interfaces
-  resource "azurerm_management_lock" "this" {
-    count = var.lock != null ? 1 : 0
-  
-    lock_level = var.lock.kind
-    name       = coalesce(var.lock.name, "lock-${var.lock.kind}")
-    scope      = azurerm_service_plan.this.id
-    notes      = var.lock.kind == "CanNotDelete" ? "Cannot delete the resource or its child resources." : "Cannot delete or modify the resource or its child resources."
-  }
-  
+resource "azurerm_management_lock" "this" {
+  count = var.lock != null ? 1 : 0
+
+  lock_level = var.lock.kind
+  name       = coalesce(var.lock.name, "lock-${var.lock.kind}")
+  scope      = azurerm_service_plan.this.id
+  notes      = var.lock.kind == "CanNotDelete" ? "Cannot delete the resource or its child resources." : "Cannot delete or modify the resource or its child resources."
+}
+
 
 resource "azurerm_role_assignment" "this" {
   for_each = var.role_assignments

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ resource "azurerm_service_plan" "this" {
   maximum_elastic_worker_count = local.maximum_elastic_worker_count
   per_site_scaling_enabled     = var.per_site_scaling_enabled
   tags                         = var.tags
-  worker_count                 = var.zone_balancing_enabled? length(data.azurerm_location.region.zone_mappings): var.worker_count
+  worker_count                 = var.zone_balancing_enabled ? length(data.azurerm_location.region.zone_mappings) : var.worker_count
   zone_balancing_enabled       = var.zone_balancing_enabled
 }
 

--- a/main.tf
+++ b/main.tf
@@ -23,13 +23,15 @@ resource "azurerm_service_plan" "this" {
 }
 
 # required AVM resources interfaces
-resource "azurerm_management_lock" "this" {
-  count = var.lock.kind != "None" ? 1 : 0
-
-  lock_level = var.lock.kind
-  name       = coalesce(var.lock.name, "lock-${var.name}")
-  scope      = azurerm_service_plan.this.id
-}
+  resource "azurerm_management_lock" "this" {
+    count = var.lock != null ? 1 : 0
+  
+    lock_level = var.lock.kind
+    name       = coalesce(var.lock.name, "lock-${var.lock.kind}")
+    scope      = azurerm_service_plan.this.id
+    notes      = var.lock.kind == "CanNotDelete" ? "Cannot delete the resource or its child resources." : "Cannot delete or modify the resource or its child resources."
+  }
+  
 
 resource "azurerm_role_assignment" "this" {
   for_each = var.role_assignments

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,10 @@ data "azurerm_resource_group" "parent" {
   name = var.resource_group_name
 }
 
+data "azurerm_location" "region" {
+  location = coalesce(var.location, local.resource_group_location)
+}
+
 resource "azurerm_service_plan" "this" {
   location                     = coalesce(var.location, local.resource_group_location)
   name                         = var.name # calling code must supply the name
@@ -14,7 +18,7 @@ resource "azurerm_service_plan" "this" {
   maximum_elastic_worker_count = local.maximum_elastic_worker_count
   per_site_scaling_enabled     = var.per_site_scaling_enabled
   tags                         = var.tags
-  worker_count                 = var.worker_count
+  worker_count                 = var.zone_balancing_enabled? length(data.azurerm_location.region.zone_mappings): var.worker_count
   zone_balancing_enabled       = var.zone_balancing_enabled
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -143,7 +143,6 @@ variable "role_assignments" {
     delegated_managed_identity_resource_id = optional(string, null)
   }))
   default     = {}
-  nullable    = false
   description = <<DESCRIPTION
   A map of role assignments to create on the Key Vault. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
   
@@ -156,10 +155,7 @@ variable "role_assignments" {
   
   > Note: only set `skip_service_principal_aad_check` to true if you are assigning a role to a service principal.
   DESCRIPTION
-}
-
-locals {
-  role_definition_resource_substring = "providers/Microsoft.Authorization/roleDefinitions"
+  nullable    = false
 }
 
 # tflint-ignore: terraform_unused_declarations

--- a/variables.tf
+++ b/variables.tf
@@ -40,20 +40,6 @@ variable "app_service_environment_id" {
   description = "Optional: The ID of the App Service Environment."
 }
 
-# required AVM interfaces
-# remove only if not supported by the resource
-# tflint-ignore: terraform_unused_declarations
-variable "customer_managed_key" {
-  type = object({
-    key_vault_resource_id              = optional(string)
-    key_name                           = optional(string)
-    key_version                        = optional(string, null)
-    user_assigned_identity_resource_id = optional(string, null)
-  })
-  default     = {}
-  description = "Customer managed keys that should be associated with the resource."
-}
-
 variable "diagnostic_settings" {
   type = map(object({
     name                                     = optional(string, null)
@@ -117,27 +103,21 @@ variable "location" {
 
 variable "lock" {
   type = object({
+    kind = string
     name = optional(string, null)
-    kind = optional(string, "None")
   })
-  default     = {}
-  description = "The lock level to apply. Default is `None`. Possible values are `None`, `CanNotDelete`, and `ReadOnly`."
-  nullable    = false
+  default     = null
+  description = <<DESCRIPTION
+  Controls the Resource Lock configuration for this resource. The following properties can be specified:
+  
+  - `kind` - (Required) The type of lock. Possible values are `\"CanNotDelete\"` and `\"ReadOnly\"`.
+  - `name` - (Optional) The name of the lock. If not specified, a name will be generated based on the `kind` value. Changing this forces the creation of a new resource.
+  DESCRIPTION
 
   validation {
-    condition     = contains(["CanNotDelete", "ReadOnly", "None"], var.lock.kind)
-    error_message = "The lock level must be one of: 'None', 'CanNotDelete', or 'ReadOnly'."
+    condition     = var.lock != null ? contains(["CanNotDelete", "ReadOnly"], var.lock.kind) : true
+    error_message = "Lock kind must be either `\"CanNotDelete\"` or `\"ReadOnly\"`."
   }
-}
-
-# tflint-ignore: terraform_unused_declarations
-variable "managed_identities" {
-  type = object({
-    system_assigned            = optional(bool, false)
-    user_assigned_resource_ids = optional(set(string), [])
-  })
-  default     = {}
-  description = "Managed identities to be created for the resource."
 }
 
 variable "maximum_elastic_worker_count" {
@@ -179,9 +159,9 @@ DESCRIPTION
 
 # tflint-ignore: terraform_unused_declarations
 variable "tags" {
-  type        = map(any)
-  default     = {}
-  description = "The map of tags to be applied to the resource"
+  type        = map(string)
+  default     = null
+  description = "(Optional) Tags of the resource."
 }
 
 variable "worker_count" {

--- a/variables.tf
+++ b/variables.tf
@@ -143,18 +143,23 @@ variable "role_assignments" {
     delegated_managed_identity_resource_id = optional(string, null)
   }))
   default     = {}
+  nullable    = false
   description = <<DESCRIPTION
-A map of role assignments to create on this resource. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
+  A map of role assignments to create on the Key Vault. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
+  
+  - `role_definition_id_or_name` - The ID or name of the role definition to assign to the principal.
+  - `principal_id` - The ID of the principal to assign the role to.
+  - `description` - The description of the role assignment.
+  - `skip_service_principal_aad_check` - If set to true, skips the Azure Active Directory check for the service principal in the tenant. Defaults to false.
+  - `condition` - The condition which will be used to scope the role assignment.
+  - `condition_version` - The version of the condition syntax. Leave as `null` if you are not using a condition, if you are then valid values are '2.0'.
+  
+  > Note: only set `skip_service_principal_aad_check` to true if you are assigning a role to a service principal.
+  DESCRIPTION
+}
 
-- `role_definition_id_or_name` - The ID or name of the role definition to assign to the principal.
-- `principal_id` - The ID of the principal to assign the role to.
-- `description` - The description of the role assignment.
-- `skip_service_principal_aad_check` - If set to true, skips the Azure Active Directory check for the service principal in the tenant. Defaults to false.
-- `condition` - The condition which will be used to scope the role assignment.
-- `condition_version` - The version of the condition syntax. Valid values are '2.0'.
-
-> Note: only set `skip_service_principal_aad_check` to true if you are assigning a role to a service principal.
-DESCRIPTION
+locals {
+  role_definition_resource_substring = "providers/Microsoft.Authorization/roleDefinitions"
 }
 
 # tflint-ignore: terraform_unused_declarations

--- a/variables.tf
+++ b/variables.tf
@@ -192,6 +192,6 @@ variable "worker_count" {
 
 variable "zone_balancing_enabled" {
   type        = bool
-  default     = false
+  default     = true
   description = "Should zone balancing be enabled for this App Service Plan."
 }


### PR DESCRIPTION
## Description
- Added logic to module to set worker_count equal to the number of AZs available in a region
- Changed zone_balancing default to true
- Updated example to use SKU that supports zone balancing
- Updated documentation

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `locals.version.tf.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `locals.version.tf.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `locals.version.tf.json`.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
