### PR TITLE
Zone redundancy instance distribution flexibility and FC1 handling improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,11 +179,11 @@ Default: `null`
 
 ### <a name="input_worker_count"></a> [worker\_count](#input\_worker\_count)
 
-Description: The number of workers to allocate for this App Service Plan.
+Description: The number of workers to allocate for this App Service Plan. Defaults to 3 for most SKUs. For Y1 and FC1 SKUs, this parameter is automatically omitted as these consumption-based plans don't support worker count configuration.
 
 Type: `number`
 
-Default: `3`
+Default: `null`
 
 ### <a name="input_zone_balancing_enabled"></a> [zone\_balancing\_enabled](#input\_zone\_balancing\_enabled)
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,8 +1,4 @@
 locals {
   maximum_elastic_worker_count       = can(regex("EP1|EP2|EP3|WS1|WS2|WS3", var.sku_name)) ? var.maximum_elastic_worker_count : null
   role_definition_resource_substring = "/providers/Microsoft.Authorization/roleDefinitions"
-  worker_count = (
-    can(regex("Y1|FC1", var.sku_name)) ? 0 :
-    var.worker_count
-  )
 }

--- a/main.tf
+++ b/main.tf
@@ -9,8 +9,11 @@ resource "azurerm_service_plan" "this" {
   per_site_scaling_enabled        = var.per_site_scaling_enabled
   premium_plan_auto_scale_enabled = startswith(var.sku_name, "P") ? var.premium_plan_auto_scale_enabled : false
   tags                            = var.tags
-  worker_count                    = local.worker_count
-  zone_balancing_enabled          = var.zone_balancing_enabled
+  # Only set worker_count for non-consumption SKUs (Y1 and FC1 don't support worker_count parameter)
+  # For consumption SKUs, omit the parameter entirely by setting to null
+  # For other SKUs, use provided value or default to 3
+  worker_count           = can(regex("Y1|FC1", var.sku_name)) ? null : coalesce(var.worker_count, 3)
+  zone_balancing_enabled = var.zone_balancing_enabled
 }
 
 # required AVM resources interfaces

--- a/variables.tf
+++ b/variables.tf
@@ -135,12 +135,12 @@ variable "tags" {
 
 variable "worker_count" {
   type        = number
-  default     = 3
-  description = "The number of workers to allocate for this App Service Plan."
+  default     = null
+  description = "The number of workers to allocate for this App Service Plan. Defaults to 3 for most SKUs. For Y1 and FC1 SKUs, this parameter is automatically omitted as these consumption-based plans don't support worker count configuration."
 
   validation {
-    condition     = (var.zone_balancing_enabled && var.sku_name != "Y1") ? var.worker_count >= 2 : true
-    error_message = "When zone_balancing_enabled is true, worker_count must be at least 2 (except for Y1 SKU which uses 0 workers)."
+    condition     = var.worker_count == null || ((var.zone_balancing_enabled && !can(regex("Y1|FC1", var.sku_name))) ? var.worker_count >= 2 : true)
+    error_message = "When zone_balancing_enabled is true, worker_count must be at least 2 (except for Y1 and FC1 SKUs where worker_count should not be specified)."
   }
 }
 


### PR DESCRIPTION
This change covers two issues:

- Allows for more flexible instance count behavior when zone redundancy is enabled, including scaling down to 2, described in #116
- FC1 SKU (Flex Consumption plan) handling improvements to allow for scaling to 0 workers as well as similar improvements for legacy Y1 SKU, described in #117 

Fixes #116
Fixes #117
Closes #116
Closes #117

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [X] Non-module change (e.g. CI/CD, documentation, etc.)
- [X] Azure Verified Module updates:
  - [X] Bugfix containing backwards compatible bug fixes
    - [X] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [X] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
