### PR TITLE
feat: allow overriding resource type

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,14 @@ map(object({
 
 Default: `{}`
 
+### <a name="input_server_farm_resource_type"></a> [server\_farm\_resource\_type](#input\_server\_farm\_resource\_type)
+
+Description: The resource type for the server farm. Defaults to `Microsoft.Web/serverfarms`.
+
+Type: `string`
+
+Default: `"Microsoft.Web/serverfarms@2025-03-01"`
+
 ### <a name="input_sku_name"></a> [sku\_name](#input\_sku\_name)
 
 Description: The SKU name of the service plan. Defaults to `P1v2`.

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ resource "azapi_resource" "this" {
   location  = var.location
   name      = var.name
   parent_id = var.parent_id
-  type      = "Microsoft.Web/serverfarms@2025-03-01"
+  type      = var.server_farm_resource_type
   body = {
     kind = local.kind
     properties = {

--- a/variables.tf
+++ b/variables.tf
@@ -268,6 +268,12 @@ variable "role_assignments" {
   nullable    = false
 }
 
+variable "server_farm_resource_type" {
+  type        = string
+  default     = "Microsoft.Web/serverfarms@2025-03-01"
+  description = "The resource type for the server farm. Defaults to `Microsoft.Web/serverfarms`."
+}
+
 variable "sku_name" {
   type        = string
   default     = "P1v2" # P1v2 is the minimum SKU for zone redundancy


### PR DESCRIPTION
## Description

Allow specifiying the server farm resource type.

Fixes https://github.com/Azure/terraform-azurerm-avm-res-web-serverfarm/issues/122


## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
