### PR TITLE
fix: remove serverFarmId casing replace that causes perpetual plan diff

### DIFF
--- a/avm
+++ b/avm
@@ -173,6 +173,15 @@ if [ -f "avm.config.json" ]; then
   done
 fi
 
+# Forward AVM_BARE_* environment variables to the container with the prefix stripped
+while IFS='=' read -r bareKey bareValue; do
+  [ -z "$bareKey" ] && continue
+  strippedKey="${bareKey#AVM_BARE_}"
+  export "$strippedKey"="$bareValue"
+  LOCAL_ENVIRONMENT_VARIABLES="${LOCAL_ENVIRONMENT_VARIABLES}-e $strippedKey "
+  echo "Forwarding AVM bare variable to container as: $strippedKey"
+done < <(env | grep '^AVM_BARE_' || true)
+
 # Check if we are running in a container
 # If we are then just run make directly
 if [ -z "${AVM_IN_CONTAINER}" ]; then
@@ -199,7 +208,7 @@ if [ -z "${AVM_IN_CONTAINER}" ]; then
     -e TF_IN_AUTOMATION=1 \
     ${LOCAL_ENVIRONMENT_VARIABLES} \
     --env-file <(env | grep '^TF_VAR_') \
-    --env-file <(env | grep '^AVM_') \
+    --env-file <(env | grep '^AVM_' | grep -v '^AVM_BARE_') \
     "${CONTAINER_IMAGE}" \
     make \
     TUI="${TUI}" \

--- a/avm.ps1
+++ b/avm.ps1
@@ -150,9 +150,16 @@ if (-not $env:AVM_IN_CONTAINER) {
     $dockerArgs += @("-e", "$($_.Name)=$($_.Value)")
   }
 
-  # Add AVM_ environment variables
-  Get-ChildItem env: | Where-Object { $_.Name -like "AVM_*" } | ForEach-Object {
+  # Add AVM_ environment variables (excluding AVM_BARE_* which are forwarded with the prefix stripped)
+  Get-ChildItem env: | Where-Object { $_.Name -like "AVM_*" -and $_.Name -notlike "AVM_BARE_*" } | ForEach-Object {
     $dockerArgs += @("-e", "$($_.Name)=$($_.Value)")
+  }
+
+  # Forward AVM_BARE_* environment variables to the container with the prefix stripped
+  Get-ChildItem env: | Where-Object { $_.Name -like "AVM_BARE_*" } | ForEach-Object {
+    $strippedName = $_.Name -replace '^AVM_BARE_', ''
+    $dockerArgs += @("-e", "$strippedName=$($_.Value)")
+    Write-Host "Forwarding AVM bare variable to container as: $strippedName"
   }
 
   # Add local environment variables from avm.config.json

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,5 +5,5 @@ output "name" {
 
 output "resource_id" {
   description = "Resource id of the app service plan"
-  value       = replace(azapi_resource.this.id, "Microsoft.Web/serverfarms/", "Microsoft.Web/serverFarms/")
+  value       = azapi_resource.this.id
 }


### PR DESCRIPTION
## Summary

Removes the `replace()` function from the `resource_id` output that was converting Azure's returned `serverfarms` (lowercase) to `serverFarms` (uppercase F).

## Problem

Every `terraform plan` shows a perpetual diff for consumers using this module's `resource_id` output as a `serverFarmId` property:

`
~ serverFarmId = ".../Microsoft.Web/serverfarms/..." -> ".../Microsoft.Web/serverFarms/..."
`

## Root Cause

When this module migrated from `azurerm_service_plan` to `azapi_resource`, the resource ID casing changed:

- **azurerm provider** constructs IDs with canonical casing (`serverFarms`, uppercase F)
- **azapi provider** returns IDs as Azure's API returns them (`serverfarms`, lowercase f)

Issue #129 added a `replace()` to the output to preserve the old uppercase casing for `azurerm` consumers. However, this causes perpetual drift for `azapi` consumers (the intended audience of this azapi-based module) because Azure normalizes the ID back to lowercase on every read.

## Fix

Remove the `replace()` and output the ID exactly as Azure returns it. Since this module is fully azapi-based, its outputs should match Azure's reality. Consumers still using `azurerm` resources downstream can apply their own `replace()` if needed.

## Validation

- Deployed a server farm + web app referencing its `resource_id` as `serverFarmId`
- Confirmed the perpetual diff exists with the old code
- Applied the fix and verified idempotency (2 consecutive applies, no changes)
- Clean destroy completed successfully
- Pre-commit checks passed

Closes #131