### PR TITLE
Fix external autoscale capacity drift

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ Default: `null`
 
 ### <a name="input_worker_count"></a> [worker\_count](#input\_worker\_count)
 
-Description: The number of workers to allocate for this App Service Plan. Defaults to `3`, which is the recommended minimum for production workloads.
+Description: The number of workers to allocate for this App Service Plan. Defaults to `3`, which is the recommended minimum for production workloads. Set to `null` when worker count is managed by an external autoscale setting.
 
 Type: `number`
 
@@ -439,7 +439,7 @@ The following Modules are called:
 
 Source: Azure/avm-utl-interfaces/azure
 
-Version: 0.5.0
+Version: 0.6.0
 
 <!-- markdownlint-disable-next-line MD041 -->
 ## Data Collection

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -32,7 +32,7 @@ resource "random_integer" "region_index" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules
@@ -176,7 +176,7 @@ The following Modules are called:
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_test"></a> [test](#module\_test)
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -25,7 +25,7 @@ resource "random_integer" "region_index" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -32,7 +32,7 @@ resource "random_integer" "region_index" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules
@@ -118,7 +118,7 @@ The following Modules are called:
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_test"></a> [test](#module\_test)
 

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -25,7 +25,7 @@ resource "random_integer" "region_index" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules

--- a/examples/linux/README.md
+++ b/examples/linux/README.md
@@ -32,7 +32,7 @@ resource "random_integer" "region_index" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules
@@ -113,7 +113,7 @@ The following Modules are called:
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_test"></a> [test](#module\_test)
 

--- a/examples/linux/main.tf
+++ b/examples/linux/main.tf
@@ -25,7 +25,7 @@ resource "random_integer" "region_index" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules

--- a/examples/managed_instance/README.md
+++ b/examples/managed_instance/README.md
@@ -56,7 +56,7 @@ resource "random_integer" "region_index" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules
@@ -566,7 +566,7 @@ The following Modules are called:
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_test"></a> [test](#module\_test)
 

--- a/examples/managed_instance/main.tf
+++ b/examples/managed_instance/main.tf
@@ -44,7 +44,7 @@ resource "random_integer" "region_index" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules

--- a/examples/multi_kind/README.md
+++ b/examples/multi_kind/README.md
@@ -39,7 +39,7 @@ resource "random_integer" "region_index" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules
@@ -124,7 +124,7 @@ The following Modules are called:
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_test"></a> [test](#module\_test)
 

--- a/examples/multi_kind/main.tf
+++ b/examples/multi_kind/main.tf
@@ -25,7 +25,7 @@ resource "random_integer" "region_index" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules

--- a/examples/windows_container/README.md
+++ b/examples/windows_container/README.md
@@ -32,7 +32,7 @@ resource "random_integer" "region_index" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules
@@ -115,7 +115,7 @@ The following Modules are called:
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_test"></a> [test](#module\_test)
 

--- a/examples/windows_container/main.tf
+++ b/examples/windows_container/main.tf
@@ -25,7 +25,7 @@ resource "random_integer" "region_index" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules

--- a/locals.tf
+++ b/locals.tf
@@ -23,7 +23,7 @@ locals {
   maximum_elastic_worker_count = can(regex("^(EP|WS|FC)", var.sku_name)) ? var.maximum_elastic_worker_count : var.worker_count
   # Normalized (lowercased, spaces removed) location used to compare against geoRegions display names.
   normalized_location = replace(lower(var.location), " ", "")
-  # FC1 capacity is managed by Azure (always 0), other SKUs use worker_count
+  # FC1 capacity is managed by Azure (always 0), other SKUs use worker_count when supplied.
   sku_capacity = local.is_flex_consumption ? 0 : var.worker_count
   # FC1 (Flex Consumption) zone redundancy is only available in a subset of Azure regions.
   # When it is requested, query the regions that advertise the FCZONEREDUNDANCY capability so the

--- a/main.telemetry.tf
+++ b/main.telemetry.tf
@@ -1,4 +1,3 @@
-
 data "modtm_module_source" "telemetry" {
   count = var.enable_telemetry ? 1 : 0
 
@@ -20,6 +19,7 @@ resource "modtm_telemetry" "telemetry" {
     random_id       = one(random_uuid.telemetry).result
   }, { location = local.main_location })
 }
+
 locals {
   valid_module_source_regex = [
     "registry.terraform.io/[A|a]zure/.+",

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 # AVM Interfaces module for locks, role assignments, diagnostic settings, and managed identities
 module "avm_interfaces" {
   source  = "Azure/avm-utl-interfaces/azure"
-  version = "0.5.0"
+  version = "0.6.0"
 
   diagnostic_settings_v2                    = var.diagnostic_settings
   enable_telemetry                          = var.enable_telemetry
@@ -74,18 +74,22 @@ resource "azapi_resource" "this" {
       workerTierName     = null
       zoneRedundant      = var.zone_balancing_enabled
       },
-      # FC1 (Flex Consumption) maximumElasticWorkerCount is managed by Azure; omit it so ignore_missing_property handles drift
-      local.is_flex_consumption ? {} : {
+      # FC1 and externally scaled plans omit maximumElasticWorkerCount so ignore_missing_property handles drift.
+      local.is_flex_consumption || local.maximum_elastic_worker_count == null ? {} : {
         maximumElasticWorkerCount = local.maximum_elastic_worker_count
       }
     )
-    sku = {
-      name     = var.sku_name
-      capacity = local.sku_capacity
-      family   = null
-      size     = null
-      tier     = null
-    }
+    sku = merge(
+      {
+        name   = var.sku_name
+        family = null
+        size   = null
+        tier   = null
+      },
+      local.sku_capacity == null ? {} : {
+        capacity = local.sku_capacity
+      }
+    )
   }
   create_headers            = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers            = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
@@ -104,6 +108,7 @@ resource "azapi_resource" "this" {
       identity_ids = identity.value.identity_ids
     }
   }
+
   dynamic "timeouts" {
     for_each = var.timeouts != null ? { this = var.timeouts } : {}
 

--- a/tests/unit/unit.tftest.hcl
+++ b/tests/unit/unit.tftest.hcl
@@ -63,6 +63,33 @@ run "non_flex_skips_region_lookup" {
     condition     = can(azapi_resource.this)
     error_message = "The App Service Plan should be created for a standard SKU."
   }
+
+  assert {
+    condition     = azapi_resource.this.body.sku.capacity == 3
+    error_message = "The App Service Plan should manage SKU capacity by default."
+  }
+}
+
+# worker_count = null supports external autoscale by omitting capacity fields that Azure Monitor owns.
+run "worker_count_null_omits_capacity" {
+  command = apply
+
+  variables {
+    location               = "westus"
+    sku_name               = "S1"
+    worker_count           = null
+    zone_balancing_enabled = false
+  }
+
+  assert {
+    condition     = !contains(keys(azapi_resource.this.body.sku), "capacity")
+    error_message = "SKU capacity must be omitted when worker_count is null."
+  }
+
+  assert {
+    condition     = !contains(keys(azapi_resource.this.body.properties), "maximumElasticWorkerCount")
+    error_message = "maximumElasticWorkerCount must be omitted when worker_count is null for non-elastic SKUs."
+  }
 }
 
 # FC1 + zone balancing in a supported region must pass the precondition and create the plan.

--- a/variables.tf
+++ b/variables.tf
@@ -341,7 +341,7 @@ variable "virtual_network_subnet_id" {
 variable "worker_count" {
   type        = number
   default     = 3
-  description = "The number of workers to allocate for this App Service Plan. Defaults to `3`, which is the recommended minimum for production workloads."
+  description = "The number of workers to allocate for this App Service Plan. Defaults to `3`, which is the recommended minimum for production workloads. Set to `null` when worker count is managed by an external autoscale setting."
 }
 
 variable "zone_balancing_enabled" {


### PR DESCRIPTION
## Summary

Fixes #145.

This PR adds a surgical opt-out for module-managed App Service Plan worker capacity: setting `worker_count = null` now omits `body.sku.capacity` and the non-elastic `maximumElasticWorkerCount` value so external Azure Monitor autoscale can own live capacity without Terraform continuously planning to reset it.

It also rolls up the currently open Dependabot changes:

- #136: `Azure/avm-utl-interfaces/azure` `0.5.0` -> `0.6.0`
- #137-#142: `Azure/naming/azurerm` examples `0.4.2` -> `0.4.3`
- #146: `actions/checkout` `6.0.3` -> `7.0.0`

## Validation

- Reproduced the issue in Azure sandbox with a temporary App Service Plan in `australiaeast`: module `worker_count = 1`, external autoscale/live capacity set to `2`, then `terraform plan` showed drift resetting `body.sku.capacity = 2 -> 1` and `maximumElasticWorkerCount = 2 -> 1`.
- Validated the fix against the same Azure resource by setting `worker_count = null`: `terraform plan -detailed-exitcode` returned `0`, `terraform apply` made no changes, and live Azure capacity remained `2`.
- Cleaned up the temporary Azure repro resource group after validation.
- `PORCH_NO_TUI=1 ./avm tf-test-unit` passed.
- `PORCH_NO_TUI=1 ./avm pre-commit` passed.
- `PORCH_NO_TUI=1 ./avm pr-check` passed docs/mapotf/tflint but the well-architected example plans failed due Azure CLI token cache inside the AVM/Terraform auth path (`User ... does not exist in MSAL token cache. Run az login`). Host `az account show` and `az account get-access-token` succeed, and unrelated examples in that same phase completed successfully.